### PR TITLE
fix js sort

### DIFF
--- a/sort-benchmark.js
+++ b/sort-benchmark.js
@@ -19,7 +19,7 @@ function main() {
   shuffle(nums);
 
   var start = Date.now();
-  nums.sort();
+  nums.sort(function(a, b) { return a - b });
   var end = Date.now();
   console.log('Sorted', N, 'ints in', end - start, 'ms');
 }


### PR DESCRIPTION
The default JS sort comparator is comparing converted string values so it won't sort nums numerically. The corrected version runs notably faster (and produces correct output).